### PR TITLE
Remove unused ReadyToUse section

### DIFF
--- a/placed-webapp/src/pages/Index.tsx
+++ b/placed-webapp/src/pages/Index.tsx
@@ -3,7 +3,6 @@ import Header from '../components/Header';
 import Hero from '../components/Hero';
 import AIRevolution from '../components/AIRevolution';
 import KIVertriebsmitarbeiter from '../components/KIVertriebsmitarbeiter';
-import ReadyToUse from '../components/ReadyToUse';
 import ComparisonSection from '../components/ComparisonSection';
 import FAQ from '../components/FAQ';
 import Footer from '../components/Footer';
@@ -16,7 +15,6 @@ const Index = () => {
         <Hero />
         <AIRevolution />
         <KIVertriebsmitarbeiter />
-        <ReadyToUse />
         <ComparisonSection />
         <FAQ />
       </main>


### PR DESCRIPTION
## Summary
- remove ReadyToUse import and component from home page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685573884cac8323b79b64d219c94dc3