### PR TITLE
Update primary CTA button styling

### DIFF
--- a/placed-webapp/src/components/PrimaryButton.tsx
+++ b/placed-webapp/src/components/PrimaryButton.tsx
@@ -1,30 +1,34 @@
-import { ArrowRight } from 'lucide-react';
-import { Button, ButtonProps } from './ui/button';
-import { cn } from '@/lib/utils';
-import React from 'react';
+import { ArrowRight } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import React from 'react'
 
-interface PrimaryButtonProps extends ButtonProps {
-  label?: string;
+interface PrimaryButtonProps
+  extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  label?: string
 }
 
-const PrimaryButton = React.forwardRef<HTMLButtonElement, PrimaryButtonProps>(
+const PrimaryButton = React.forwardRef<HTMLAnchorElement, PrimaryButtonProps>(
   ({ label = 'Demo buchen', className, children, ...props }, ref) => {
     return (
-      <Button
+      <a
+        href="https://meetings-eu1.hubspot.com/ftemel?uuid=3b67042c-5da5-41d6-868a-3b46daf91409"
+        target="_blank"
+        rel="noopener noreferrer"
         ref={ref}
         className={cn(
-          'bg-[#EBFF4A] text-gray-900 font-semibold text-sm md:text-base px-4 md:px-6 py-2.5 md:py-3 rounded-full shadow-md shadow-yellow-200/50 hover:shadow-lg hover:-translate-y-[1px] transition-all duration-200 ease-in-out inline-flex items-center gap-x-2 group',
-          className
+          'inline-flex items-center justify-center gap-x-2 px-6 py-3 rounded-full bg-[#EBFF4A] text-gray-900 font-semibold text-base shadow-md hover:shadow-lg hover:brightness-95 active:scale-[0.97] transition-all duration-200 group',
+          className,
         )}
         aria-label="Jetzt Demo buchen"
         {...props}
       >
         {children ?? label}
-        <ArrowRight className="h-5 w-5 text-gray-800 group-hover:translate-x-1 transition-transform duration-200" />
-      </Button>
-    );
-  }
-);
-PrimaryButton.displayName = 'PrimaryButton';
+        <ArrowRight className="h-5 w-5 text-gray-700 transition-transform group-hover:translate-x-1" />
+      </a>
+    )
+  },
+)
+PrimaryButton.displayName = 'PrimaryButton'
 
-export default PrimaryButton;
+export default PrimaryButton
+


### PR DESCRIPTION
## Summary
- redesign the primary CTA button and convert it to an anchor element

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685586f658fc832389a126f868235f0a