### PR TITLE
Fix event listener registration in toast hook

### DIFF
--- a/placed-webapp/src/hooks/use-toast.ts
+++ b/placed-webapp/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- avoid re-registering state listener on every toast update

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_b_685596db55b48324b86966787eb8804e